### PR TITLE
Add `--develop` flag to our run script change `knic-engine` location for local development

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "build:prod": "jlpm clean && jlpm build:lib && jlpm build:labextension",
         "build:labextension": "jupyter labextension build .",
         "build:labextension:dev": "jupyter labextension build --development True .",
+        "build:lib:dev": "SERVER_ENDPOINT=$SERVER_ENDPOINT tsc",
         "build:lib": "tsc",
         "clean": "jlpm clean:lib",
         "clean:lib": "rimraf lib tsconfig.tsbuildinfo",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
         "@types/jest": "^26.0.0",
         "@typescript-eslint/eslint-plugin": "^4.8.1",
         "@typescript-eslint/parser": "^4.8.1",
+        "cross-env": "^7.0.3",
         "eslint": "^7.14.0",
         "eslint-config-prettier": "^6.15.0",
         "eslint-plugin-prettier": "^3.1.4",

--- a/run-jupyter-lab.sh
+++ b/run-jupyter-lab.sh
@@ -13,15 +13,14 @@ DEVELOPMENT_ENDPOINT="http://localhost:5642/knic"
 # Rebuild Jupyter Lab library to work with `knic-engine` running on localhost
 if [ "$DEVELOP" = "--develop" ] ; then
     echo "Running Jupyter Lab in DEVELOPMENT mode.."
-    echo "Changing location of knic-engine to 'http://localhost:5642/knic'.."
-    echo "Changing 'src/index.ts' file to rebuild with new knic-engine location: $DEVELOPMENT_ENDPOINT"
+    echo "Changing 'src/index.ts' file to rebuild with our new location for knic-engine: $DEVELOPMENT_ENDPOINT"
     sed "s|$PRODUCTION_ENDPOINT|$DEVELOPMENT_ENDPOINT|g" $DIR/src/index.ts >> $DIR/src/temp.ts
     mv $DIR/src/temp.ts $DIR/src/index.ts
     pip install -ve .
     jupyter lab --no-browser --allow-root --port $PORT --config=$CONFIG
 else
     echo "Running Jupyter Lab in PRODUCTION mode.."
-    echo "Changing 'src/index.ts' file to rebuild with new knic-engine location: $PRODUCTION_ENDPOINT"
+    echo "Changing 'src/index.ts' file to rebuild with our new location for knic-engine: $PRODUCTION_ENDPOINT"
     sed "s|$DEVELOPMENT_ENDPOINT|$PRODUCTION_ENDPOINT|g" $DIR/src/index.ts >> $DIR/src/temp.ts
     mv $DIR/src/temp.ts $DIR/src/index.ts
     pip install -ve .

--- a/run-jupyter-lab.sh
+++ b/run-jupyter-lab.sh
@@ -16,13 +16,14 @@ if [ "$DEVELOP" = "--develop" ] ; then
     echo "Changing 'src/index.ts' file to rebuild with our new location for knic-engine: $DEVELOPMENT_ENDPOINT"
     sed "s|$PRODUCTION_ENDPOINT|$DEVELOPMENT_ENDPOINT|g" $DIR/src/index.ts >> $DIR/src/temp.ts
     mv $DIR/src/temp.ts $DIR/src/index.ts
-    pip install -ve .
-    jupyter lab --no-browser --allow-root --port $PORT --config=$CONFIG
+    sed -n '50p' $DIR/src/index.ts
 else
     echo "Running Jupyter Lab in PRODUCTION mode.."
     echo "Changing 'src/index.ts' file to rebuild with our new location for knic-engine: $PRODUCTION_ENDPOINT"
     sed "s|$DEVELOPMENT_ENDPOINT|$PRODUCTION_ENDPOINT|g" $DIR/src/index.ts >> $DIR/src/temp.ts
     mv $DIR/src/temp.ts $DIR/src/index.ts
-    pip install -ve .
-    jupyter lab --no-browser --allow-root --port $PORT --config=$CONFIG
+    sed -n '50p' $DIR/src/index.ts
 fi
+
+pip install -ve .
+jupyter lab --no-browser --allow-root --port $PORT --config=$CONFIG

--- a/run-jupyter-lab.sh
+++ b/run-jupyter-lab.sh
@@ -5,5 +5,17 @@ PORT=5644
 # Get the absolute path to the `knic-jupyter` directory
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 CONFIG="$DIR/config.py"
+DEVELOP=$1
 
-jupyter lab --no-browser --allow-root --port $PORT --config=$CONFIG
+# Rebuild Jupyter Lab library to work with `knic-engine` running on localhost
+if [ "$DEVELOP" = "--develop" ] ; then
+    echo "Running Jupyter Lab in development mode.."
+    echo "Changing location of knic-engine to 'http://localhost:5642/knic'.."
+    echo "Running the 'npm run build:lib' command to rebuild with new location.."
+    jupyter lab --no-browser --allow-root --port $PORT --config=$CONFIG
+else
+    echo "Running Jupyter Lab in production mode.."
+    echo "Location of knic-engine is set to 'https://knic.isi.edu/engine'.."
+    npm run build:lib
+    jupyter lab --no-browser --allow-root --port $PORT --config=$CONFIG
+fi

--- a/run-jupyter-lab.sh
+++ b/run-jupyter-lab.sh
@@ -12,7 +12,7 @@ DEVELOPMENT_ENDPOINT="http://localhost:5642/knic"
 
 # Rebuild Jupyter Lab library to work with `knic-engine` running on localhost
 if [ "$DEVELOP" = "--develop" ] ; then
-    echo "Running Jupyter Lab in development mode.."
+    echo "Running Jupyter Lab in DEVELOPMENT mode.."
     echo "Changing location of knic-engine to 'http://localhost:5642/knic'.."
     echo "Changing 'src/index.ts' file to rebuild with new knic-engine location: $DEVELOPMENT_ENDPOINT"
     sed "s|$PRODUCTION_ENDPOINT|$DEVELOPMENT_ENDPOINT|g" $DIR/src/index.ts >> $DIR/src/temp.ts
@@ -20,7 +20,7 @@ if [ "$DEVELOP" = "--develop" ] ; then
     pip install -ve .
     jupyter lab --no-browser --allow-root --port $PORT --config=$CONFIG
 else
-    echo "Running Jupyter Lab in production mode.."
+    echo "Running Jupyter Lab in PRODUCTION mode.."
     echo "Changing 'src/index.ts' file to rebuild with new knic-engine location: $PRODUCTION_ENDPOINT"
     sed "s|$DEVELOPMENT_ENDPOINT|$PRODUCTION_ENDPOINT|g" $DIR/src/index.ts >> $DIR/src/temp.ts
     mv $DIR/src/temp.ts $DIR/src/index.ts

--- a/run-jupyter-lab.sh
+++ b/run-jupyter-lab.sh
@@ -7,22 +7,23 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 CONFIG="$DIR/config.py"
 DEVELOP=$1
 
+PRODUCTION_ENDPOINT="https://knic.isi.edu/engine"
+DEVELOPMENT_ENDPOINT="http://localhost:5642/knic"
+
 # Rebuild Jupyter Lab library to work with `knic-engine` running on localhost
 if [ "$DEVELOP" = "--develop" ] ; then
     echo "Running Jupyter Lab in development mode.."
     echo "Changing location of knic-engine to 'http://localhost:5642/knic'.."
-    echo "Running the 'npm run build:lib' command to rebuild with new location.."
-    export SERVER_ENDPOINT="http://localhost:5642/knic"
-    echo $SERVER_ENDPOINT
-    jupyter lab clean
-    npm run clean:all
-    npm run build:lib:dev
-    npm run build:labextension
-    npm run install:extension
+    echo "Changing 'src/index.ts' file to rebuild with new knic-engine location: $DEVELOPMENT_ENDPOINT"
+    sed "s|$PRODUCTION_ENDPOINT|$DEVELOPMENT_ENDPOINT|g" $DIR/src/index.ts >> $DIR/src/temp.ts
+    mv $DIR/src/temp.ts $DIR/src/index.ts
+    pip install -ve .
     jupyter lab --no-browser --allow-root --port $PORT --config=$CONFIG
 else
     echo "Running Jupyter Lab in production mode.."
-    echo "Location of knic-engine is set to 'https://knic.isi.edu/engine'.."
-    npm run build:lib
+    echo "Changing 'src/index.ts' file to rebuild with new knic-engine location: $PRODUCTION_ENDPOINT"
+    sed "s|$DEVELOPMENT_ENDPOINT|$PRODUCTION_ENDPOINT|g" $DIR/src/index.ts >> $DIR/src/temp.ts
+    mv $DIR/src/temp.ts $DIR/src/index.ts
+    pip install -ve .
     jupyter lab --no-browser --allow-root --port $PORT --config=$CONFIG
 fi

--- a/run-jupyter-lab.sh
+++ b/run-jupyter-lab.sh
@@ -12,6 +12,12 @@ if [ "$DEVELOP" = "--develop" ] ; then
     echo "Running Jupyter Lab in development mode.."
     echo "Changing location of knic-engine to 'http://localhost:5642/knic'.."
     echo "Running the 'npm run build:lib' command to rebuild with new location.."
+    export SERVER_ENDPOINT="http://localhost:5642/knic"
+    echo $SERVER_ENDPOINT
+    npm run clean:all
+    npm run build:lib:dev
+    npm run build:labextension
+    npm run install:extension
     jupyter lab --no-browser --allow-root --port $PORT --config=$CONFIG
 else
     echo "Running Jupyter Lab in production mode.."

--- a/run-jupyter-lab.sh
+++ b/run-jupyter-lab.sh
@@ -14,6 +14,7 @@ if [ "$DEVELOP" = "--develop" ] ; then
     echo "Running the 'npm run build:lib' command to rebuild with new location.."
     export SERVER_ENDPOINT="http://localhost:5642/knic"
     echo $SERVER_ENDPOINT
+    jupyter lab clean
     npm run clean:all
     npm run build:lib:dev
     npm run build:labextension

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,9 @@ const SESSION = new URLSearchParams(window.location.search).get('sessionid');
 const SERVER_ENDPOINT = `https://knic.isi.edu/engine/user/${USER}/event`;
 
 console.log(`SERVER_ENDPOINT: ${SERVER_ENDPOINT}`)
+console.log('77777777777777777777!@#$!@#$!@#$!@#$!@#$!@#$!#$!@#$')
+const test = process.env.SERVER_ENDPOINT
+console.log(`ENV VAR TEST - SERVER_ENDPOINT: ${test}`)
 
 let ENUMERATION = 0;
 let NOTEBOOK_SESSION = UUID.uuid4();

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,9 +50,6 @@ const SESSION = new URLSearchParams(window.location.search).get('sessionid');
 const SERVER_ENDPOINT = `https://knic.isi.edu/engine/user/${USER}/event`;
 
 console.log(`SERVER_ENDPOINT: ${SERVER_ENDPOINT}`)
-console.log('77777777777777777777!@#$!@#$!@#$!@#$!@#$!@#$!#$!@#$')
-const test = process.env.SERVER_ENDPOINT
-console.log(`ENV VAR TEST - SERVER_ENDPOINT: ${test}`)
 
 let ENUMERATION = 0;
 let NOTEBOOK_SESSION = UUID.uuid4();


### PR DESCRIPTION
Now if you run `./run-jupyter-lab.sh --develop` it will automagically switch over to use:

```
DEVELOPMENT_ENDPOINT="http://localhost:5642/knic"
```

As opposed to when you regularly run `./run-jupyter-lab.sh`, in that case it would use:

```
PRODUCTION_ENDPOINT="https://knic.isi.edu/engine"
```

NOTE: In both cases, it does take around 30-40 seconds to rebuild.