### PR TITLE
Use knic on localhost by default

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ let db: Dexie;
 
 const USER = new URLSearchParams(window.location.search).get('userid');
 const SESSION = new URLSearchParams(window.location.search).get('sessionid');
-const SERVER_ENDPOINT = `https://knic.isi.edu/engine/user/${USER}/event`;
+const SERVER_ENDPOINT = `http://localhost:5642/knic/user/${USER}/event`;
 
 console.log(`SERVER_ENDPOINT: ${SERVER_ENDPOINT}`)
 


### PR DESCRIPTION
This is a manual step that has caused me problems multiple times.
I think we said that running engine on a non-local server is just not going to happen.
Is there any reason not to just make localhost be the default?