### PR TITLE
Add `/tac-eval-notebooks/` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules/
 .ipynb_checkpoints
 *.tsbuildinfo
 knic-jupyter/labextension
+/tac-eval-notebooks/
 
 # Integration tests
 ui-tests/test-results/


### PR DESCRIPTION
This is just an improvement I've had locally to make my work easier.