### PR TITLE
Fix `run-jupyter-lab.sh`

### DIFF
--- a/run-jupyter-lab.sh
+++ b/run-jupyter-lab.sh
@@ -1,10 +1,12 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -euo pipefail
 
 # Port number used for `knic-jupyter`
 PORT=5644
 
 # Get the absolute path to the `knic-jupyter` directory
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 SOURCE_FILE="$DIR/src/index.ts"
 CHANGELOG="$DIR/src/changelog.txt"
 CONFIG="$DIR/config.py"
@@ -13,26 +15,26 @@ PRODUCTION_ENDPOINT="https://knic.isi.edu/engine"
 DEVELOPMENT_ENDPOINT="http://localhost:5642/knic"
 
 # Check if the user is running Jupyter Lab in develop mode or not
-if [ "$1" = "--production" ] ; then
+if [[ ${1:-} = --production ]]; then
     echo "Running Jupyter Lab in PRODUCTION mode.."
     sed -i -e "s|$DEVELOPMENT_ENDPOINT|$PRODUCTION_ENDPOINT|gw $CHANGELOG" "$SOURCE_FILE"
-    if [ -s $CHANGELOG ]; then
-        cat $CHANGELOG
+    if [[ -s $CHANGELOG ]]; then
+        cat "$CHANGELOG"
     fi
     echo "knic-engine endpoint = $PRODUCTION_ENDPOINT"
 else
     echo "Running Jupyter Lab in DEVELOPMENT mode.."
     sed -i -e "s|$PRODUCTION_ENDPOINT|$DEVELOPMENT_ENDPOINT|gw $CHANGELOG" "$SOURCE_FILE"
-    if [ -s $CHANGELOG ]; then
-        cat $CHANGELOG
+    if [[ -s $CHANGELOG ]]; then
+        cat "$CHANGELOG"
     fi
     echo "knic-engine endpoint = $DEVELOPMENT_ENDPOINT"
 fi
 
 # Rebuild Jupyter Lab if knic-engine endpoint changed
-if [ -s $CHANGELOG ]; then
+if [[ -s $CHANGELOG ]]; then
     pip install -ve .
 fi
 
 # Run Jupyter Lab with our desired PORT and CONFIG file settings
-jupyter lab --no-browser --allow-root --port $PORT --config=$CONFIG
+jupyter lab --no-browser --allow-root --port $PORT --config="$CONFIG"

--- a/run-jupyter-lab.sh
+++ b/run-jupyter-lab.sh
@@ -15,14 +15,14 @@ DEVELOPMENT_ENDPOINT="http://localhost:5642/knic"
 # Check if the user is running Jupyter Lab in develop mode or not
 if [ "$1" = "--production" ] ; then
     echo "Running Jupyter Lab in PRODUCTION mode.."
-    sed -i "" -e "s|$DEVELOPMENT_ENDPOINT|$PRODUCTION_ENDPOINT|gw $CHANGELOG" "$SOURCE_FILE"
+    sed -i -e "s|$DEVELOPMENT_ENDPOINT|$PRODUCTION_ENDPOINT|gw $CHANGELOG" "$SOURCE_FILE"
     if [ -s $CHANGELOG ]; then
         cat $CHANGELOG
     fi
     echo "knic-engine endpoint = $PRODUCTION_ENDPOINT"
 else
     echo "Running Jupyter Lab in DEVELOPMENT mode.."
-    sed -i "" -e "s|$PRODUCTION_ENDPOINT|$DEVELOPMENT_ENDPOINT|gw $CHANGELOG" "$SOURCE_FILE"
+    sed -i -e "s|$PRODUCTION_ENDPOINT|$DEVELOPMENT_ENDPOINT|gw $CHANGELOG" "$SOURCE_FILE"
     if [ -s $CHANGELOG ]; then
         cat $CHANGELOG
     fi


### PR DESCRIPTION
I had a hack locally to run `run-jupyter-lab.sh` and have it use the proper endpoint. I have replaced it with a real fix and cleaned up the file some.

I have been using this version to run KNIC, and Jupyter works fine.