### PR TITLE
Remove attestation from image build

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -22,7 +22,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      attestations: write
       id-token: write
 
     steps:
@@ -57,11 +56,3 @@ jobs:
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
-        if: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
Apparently attestation of image builds is only supported in public repos or with organization level configuration. So we'll drop this part of the recommendation from github for now. While it would continue to operate correctly for this repo, being consistent across all three is likely better for us to manage at the moment.